### PR TITLE
Upgrade current working develop to master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "django/simssadb"]
 	path = django/simssadb
 	url = git@github.com:ELVIS-Project/simssadb.git
+	branch = develop

--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@
 - First you must install docker
   - For Mac
     - `brew cask install docker`
-    - `pip install docker-compose`
+    - `pip install docker compose`
   - For Ubuntu https://docs.docker.com/install/linux/docker-ce/ubuntu/
 
 - To View the site with no modifications
-  - Execute from the root of the repository: `docker-compose up`
+  - Execute from the root of the repository: `docker compose up`
+  - Go to ``http://127.0.0.1:1337`` on your web browser
 - To work on the Django project,
   - You require the submodules: `git clone --recurse-submodules git@github.com:DDMAL/docker-simssadb.git`
   - Check if you have the latest branch in the `django/simssadb` folder execute `git pull origin develop`
     - If the latest has a different hash than the one referenced in this repository, make sure to commit the latest hash to this repository.
-  - execute the following command from the root of the repository: `docker-compose -f build.yml build`. Alternatively, try running `sudo docker-compose up` if errors appear.
+  - execute the following command from the root of the repository: `docker compose -f build.yml build`. Alternatively, try running `sudo docker compose up` if errors appear.
   - In another terminal window, execute:
 
   ```bash

--- a/README.md
+++ b/README.md
@@ -19,8 +19,18 @@
 
   ```bash
   # This will give you a new shell
-  docker-compose exec django bash
+  docker compose exec django bash
 
   # In the new shell, type the following
   /machine/start
   ```
+**Note**: Make sure you have the correct image tags when pulling. Cross check with Docker Hub and edit the tags in `docker-compose.yml`.
+
+## Deployment
+To deploy changes made locally to production/staging:
+- Make sure Docker Hub built the images correctly: `ddmal/simssadb_django`, `ddmal/simssadb_postgres`, `ddmal/simssadb_nginx`
+- ssh into the staging or production server. Information on how to access them can be found on https://wiki.internal.simssa.ca
+- Find where the current `docker-simssadb` repo is. It's normally in `/srv/webapps/`
+- Make sure you have the correct docker image tags and run `sudo docker compose up`  
+  
+**Note**: Make sure to check for unused images, build caches, old volumes etc.

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,5 +1,5 @@
 # Get python image
-FROM python:3.7
+FROM python:3.8.17
 EXPOSE 8000
 
 # Update dependencies

--- a/misc/variables.txt
+++ b/misc/variables.txt
@@ -2,7 +2,7 @@
 # The app is reading those with os.getenv()
 
 # Django settings
-SIMSSADB_HOSTS=['*']
+SIMSSADB_HOSTS='*'
 SIMSSADB_DEBUG=True
 SIMSSADB_SECRET_KEY=f1(1=m5ze=@ne023nnabwz(%x^j+8!y+py&n#lwvo0&(#c
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15.0-alpine
+FROM nginx:1.25-alpine
 
 RUN set -e \
   && apk add --update \
@@ -6,3 +6,5 @@ RUN set -e \
     curl \
   && rm /etc/nginx/conf.d/default.conf
 COPY ./simssadb.conf /etc/nginx/conf.d/simssadb.conf
+
+EXPOSE 1337

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:11.1
+FROM postgres:12-bullseye
 EXPOSE 5432
 
 COPY ./maintenance /usr/local/bin/maintenance


### PR DESCRIPTION
The current `develop` images are running on db.simssa.ca due to a problem with the server and images. We should merge them to reflect correctly what's currently on production server.